### PR TITLE
UX: Show a warning if full-width is not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
-# peak-mode-composer
-
-**Theme Summary**
-
-For more information, please see: **url to meta topic**
+# Composer Peek Mode

--- a/about.json
+++ b/about.json
@@ -1,13 +1,6 @@
 {
-  "name": "peak-mode-composer",
+  "name": "Composer Peek Mode",
   "component": true,
   "authors": "Discourse",
-  "about_url": "TODO: Put your theme's public repo or Meta topic URL here",
-  "license_url": "TODO: Put your theme's LICENSE URL here",
-  "learn_more": "TODO",
-  "theme_version": "0.0.1",
-  "minimum_discourse_version": null,
-  "maximum_discourse_version": null,
-  "assets": {},
-  "modifiers": {}
+  "theme_version": "0.0.1"
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -63,10 +63,6 @@
 }
 
 .alert-peek-mode-dependency {
-  body:not(.staff) &,
-  body.full-width-enabled & {
-    display: none;
-  }
   text-align: center;
   margin: 0;
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -61,3 +61,17 @@
     }
   }
 }
+
+.alert-peek-mode-dependency {
+  body:not(.staff) &,
+  body.full-width-enabled & {
+    display: none;
+  }
+  text-align: center;
+  margin: 0;
+
+  .d-icon {
+    margin-right: 0.5em;
+    color: var(--primary-high);
+  }
+}

--- a/javascripts/discourse/api-initializers/full-width-requirement.gjs
+++ b/javascripts/discourse/api-initializers/full-width-requirement.gjs
@@ -1,0 +1,20 @@
+import icon from "discourse/helpers/d-icon";
+import htmlSafe from "discourse/helpers/html-safe";
+import { apiInitializer } from "discourse/lib/api";
+import { i18n } from "discourse-i18n";
+
+export default apiInitializer("1.8.0", (api) => {
+  api.renderInOutlet(
+    "below-site-header",
+    <template>
+      <div class="alert alert-info alert-peek-mode-dependency">
+        {{icon "shield-halved"}}{{htmlSafe
+          (i18n
+            (themePrefix "warning")
+            link="https://https://github.com/discourse/discourse-full-width-component"
+          )
+        }}
+      </div>
+    </template>
+  );
+});

--- a/javascripts/discourse/api-initializers/full-width-requirement.gjs
+++ b/javascripts/discourse/api-initializers/full-width-requirement.gjs
@@ -1,3 +1,4 @@
+import Component from "@glimmer/component";
 import icon from "discourse/helpers/d-icon";
 import htmlSafe from "discourse/helpers/html-safe";
 import { apiInitializer } from "discourse/lib/api";
@@ -6,15 +7,24 @@ import { i18n } from "discourse-i18n";
 export default apiInitializer("1.8.0", (api) => {
   api.renderInOutlet(
     "below-site-header",
-    <template>
-      <div class="alert alert-info alert-peek-mode-dependency">
-        {{icon "shield-halved"}}{{htmlSafe
-          (i18n
-            (themePrefix "warning")
-            link="https://https://github.com/discourse/discourse-full-width-component"
-          )
-        }}
-      </div>
-    </template>
+    class extends Component {
+      static shouldRender() {
+        const currentUser = api.container.lookup("service:currentUser");
+        const hasClass = document.querySelector(".full-width-enabled");
+
+        return currentUser?.staff && !hasClass;
+      }
+
+      <template>
+        <div class="alert alert-info alert-peek-mode-dependency">
+          {{icon "shield-halved"}}{{htmlSafe
+            (i18n
+              (themePrefix "warning")
+              link="https://github.com/discourse/discourse-full-width-component"
+            )
+          }}
+        </div>
+      </template>
+    }
   );
 });

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   theme_metadata:
-    description: ''
+    description: "Dock the composer to the right when space allows"
+  warning: "Hello admin! Composer peek mode requires the <a href='%{link}'>full-width component</a> to be installed"


### PR DESCRIPTION
This component requires full-width to be installed as well, so I've added a warning banner to help clarify. 

![image](https://github.com/user-attachments/assets/69293faf-6ed6-4f7e-a194-9bf2d77c3e2d)

I also cleaned up the theme metadata while I was at it